### PR TITLE
Fix for incorrect i2c read address issue

### DIFF
--- a/ch347api/__device.py
+++ b/ch347api/__device.py
@@ -303,11 +303,13 @@ class CH347HIDDev(hid.device):
         elif read_len == 1:
             tail = b"\xc0\x75"
             if len(data) > 1:
-                tail = b"\x74\x81\xd1" + tail
+                # Convert write address into read address
+                tail = b"\x74\x81" + bytes([data[0] | 0x01]) + tail
         elif read_len < 64:
             tail = struct.pack("<bBB", -65 + read_len, 0xc0, 0x75)
             if len(data) > 1:
-                tail = b"\x74\x81\xd1" + tail
+                # Convert write address into read address
+                tail = b"\x74\x81" + bytes([data[0] | 0x01]) + tail
         else:
             raise Exception("read length exceeded max size of 63 Bytes")
         payload = struct.pack("<BHBBB", 0x00, len(data) + len(tail) + 4, 0xaa, 0x74, len(data) | 0b1000_0000)

--- a/ch347api/__i2c.py
+++ b/ch347api/__i2c.py
@@ -48,6 +48,9 @@ def convert_int_to_bytes(inputs: (int, bytes)) -> bytes:
         while data_copy:
             b_len += 1
             data_copy = data_copy // 256
+        if b_len == 0:
+            b_len = 1 
         inputs = inputs.to_bytes(b_len, 'big', signed=False)
+        
 
     return inputs


### PR DESCRIPTION
Quick fix for the hardcoded read address for I2C. Simply takes takes the read address and sets the r/w bit to 1. Closes #10.
Also included a fix to close #12. It simply catches when an integer was detected as 0 length and sets it to 1. This catches a value of 0 being entered.